### PR TITLE
docs: document observer effect & load spikes from server MOTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ Run the collector outside Omarchy to inspect the raw snapshot:
 bun run backend/server-status.ts status --host <ssh-alias>
 ```
 
+## Troubleshooting: Load Spikes & The Observer Effect
+
+If a host unexpectedly alerts with `CPU load 100%` or enters a warning state on refresh despite sustained CPU being mostly idle, check whether the remote host runs intensive scripts in `/etc/update-motd.d/` or PAM session hooks (e.g., querying `fail2ban-client`, `podman`, container runtimes, or scanning large log files).
+
+Because the collector opens an SSH session to run its read-only script, remote PAM session scripts execute concurrently with the collector's Docker queries (`docker ps`, `docker stats`, `docker inspect`). On machines with fewer cores (such as 2–4 core VMs), executing ~10–15 short-lived processes within a 2-second window can briefly populate the kernel run queue (`/proc/loadavg`), causing the plugin's `load1 / cpuCount >= 1.0` threshold to trigger a transient `CPU load 100%` alert.
+
+**Tip for monitored hosts:**
+Guard heavy custom MOTD scripts so they execute only for interactive user logins and exit immediately for non-interactive SSH telemetry probes:
+
+```bash
+# In /etc/update-motd.d/<script>
+[ -t 1 ] || exit 0
+```
+
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a troubleshooting note to `README.md` explaining the "Observer Effect" where server status sweeps can trigger transient `CPU load 100%` alerts on hosts with rich login MOTD scripts.

---

### Context / FYI for Author

For context, the monitored node added to the plugin is an **Azure Linux VM** (Ubuntu on Azure with 4 vCPUs).

Every time the plugin connects over SSH to poll stats, it can inadvertently trigger a brief execution storm on hosts with custom interactive login environments:

1. **SSH Connection & MOTD Execution**:
   Because the plugin connects via SSH (`ssh -o BatchMode=yes ...`), PAM session hooks execute. On servers with custom `/etc/update-motd.d/` scripts (e.g. cloud/homelab VMs reporting telemetry):
   - Opening the session spawns `sudo fail2ban-client status sshd`, `podman ps -q` (mounting container storage), `incus list`, `grep -c Ban` and `grep -c Found`, `df`, `free`, and login alert hooks.
   - On Azure VMs, background services like `WALinuxAgent` / `azure.slice` and guest diagnostics run concurrently.
2. **Plugin Collection Payload (`collect.ts`)**:
   Simultaneously, the plugin payload executes:
   - `docker version`
   - `docker ps --all`
   - `docker stats --no-stream`
   - `docker inspect` across all container IDs
3. **Queue Saturation**:
   Running ~10–15 processes concurrently within a 2-second burst fills the kernel run queue (`sar -q` logged 5 active runnable processes across the 4 cores on our Azure VM).
4. **The False Alert**:
   The plugin reads `/proc/loadavg` right during that burst, sees `load1 = 5.19` (`5.19 / 4 = 1.29` -> clamped to 100%), and fires a desktop notification:
   `Server alert · <host>: CPU load 100%`.
5. **Recovery**:
   As soon as that 2-second burst finishes, the load clears, and on the subsequent scan the plugin sends the `Server recovered` notification.

---

### Proposed Documentation

This PR documents this interaction in `README.md` and provides a 1-line best practice for server administrators to guard heavy MOTD scripts (`[ -t 1 ] || exit 0`) so they only execute for interactive user logins and exit cleanly during non-interactive SSH telemetry probes.